### PR TITLE
Dedicated threads remove tokio

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,4 @@
-use tokio::time::{/*sleep,*/ Duration};
+use tokio::time::{/*sleep,*/ Instant, Duration};
 use std::sync::{Arc, Mutex, atomic, atomic::AtomicUsize};
 use colour::{e_green};
 
@@ -8,37 +8,16 @@ type Terminator = Arc<Mutex<bool>>;
 type MnemonicsTested = Arc<AtomicUsize>;
 
 pub fn threaded_logger(log_mnemonics: MnemonicsTested, terminated: Terminator, complexity: u64) {
-        let mut last_tested = 0;
-        let mut last_log_length: usize = 0;
+        let start_time = Instant::now();
         loop {
-                eprint!("{}", format!("\r{:>width$}", "", width=last_log_length));
                 let tested = log_mnemonics.load(atomic::Ordering::Relaxed);
-                let log_msg = format!("\r{:.2}% done | {} mnemonics per second", 100.*(tested as f64/complexity as f64), tested-last_tested);
-                e_green!("{}", log_msg);
-                last_log_length = log_msg.chars().count();
-                last_tested = tested;
+                let percentage = 100.*(tested as f64/complexity as f64);
+                let runtime = start_time.elapsed();
+                let per_second = (tested as f64) / (runtime.as_secs() as f64 + runtime.subsec_millis() as f64 / 1000.0);
+                e_green!("\r{:>width$}\r{:.2}% done | {} mnemonics per second", "", percentage, per_second as u64, width=50);
                 thread::sleep(Duration::from_millis(1000));
                 if  *terminated.lock().unwrap() {
                         break;
                 }
         }
 }
-
-/*
-async fn async_logger(log_mnemonics: MnemonicsTested, terminated: Terminator, complexity: u64) {
-        let mut last_tested = 0;
-        let mut last_log_length: usize = 0;
-        loop {
-                eprint!("{}", format!("\r{:>width$}", "", width=last_log_length));
-                let tested = log_mnemonics.load(atomic::Ordering::Relaxed);
-                let log_msg = format!("\r{:.2}% done | {} mnemonics per second", 100.*(tested as f64/complexity as f64), tested-last_tested);
-                e_green!("{}", log_msg);
-                last_log_length = log_msg.chars().count();
-                last_tested = tested;
-                sleep(Duration::from_millis(1000)).await;
-                if  *terminated.lock().unwrap() {
-                        break;
-                }
-        }
-}
-*/

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
         }
 
         if brute_config.ledger.use_ledger {
-                brute_ledger::run(broken_mnemonic, brute_config).await;
+                brute_ledger::run(broken_mnemonic, brute_config);
         } else {
                 brute_node::run(broken_mnemonic, brute_config).await;
         }


### PR DESCRIPTION
After testing, using a dedicated thread pool was no faster than a tokio spawn_blocking, and slower in most cases. 